### PR TITLE
sailfish/marlin: Disable KEYCTL_JOIN_SESSION_KYERING

### DIFF
--- a/security/keys/keyctl.c
+++ b/security/keys/keyctl.c
@@ -1591,7 +1591,14 @@ SYSCALL_DEFINE5(keyctl, int, option, unsigned long, arg2, unsigned long, arg3,
 					     (int) arg3);
 
 	case KEYCTL_JOIN_SESSION_KEYRING:
-		return keyctl_join_session_keyring((const char __user *) arg2);
+		// region @maru
+		// return keyctl_join_session_keyring((const char __user *) arg2);
+		// The newest systemd will call keyctl with KEYCTL_JOIN_SESSION_KEYRING
+		// to give a refresh session keyring to each service, but it will cause
+		// the process in Linux can't get correct keyring, what causes the
+		// "Required key not found" error for critical commands, such as mktemp.
+		return -1;
+		// endregion
 
 	case KEYCTL_UPDATE:
 		return keyctl_update_key((key_serial_t) arg2,


### PR DESCRIPTION
The newest `systemd` will call `keyctl` with `KEYCTL_JOIN_SESSION_KYERING`
to give a refresh session keyring to each service, but it will cause
the process in Linux can't get correct keyring, what causes the
"Required key not found" error for critical commands, such as `mktemp`.
In Debian buster, the `ENOKEY` error will cause the systemd-sysusers
service starting failed, what causes `maru-mflinger-client` envrionement
not correct, and secondary display will be blank.

Before we find better method, we will disable
`KEYCTL_JOIN_SESSION_KEYRING` command hackly. If we port maru to device
with higher version kernel, we should test it whehter we need this patch.

This patch will only modify the `keyctl.c` for `arm64`. There is a compatible version of `keyctl.c` called `security/keys/compat.c` for `armhf`.

This patch only work for `sailfish/marlin` now, and I test it with `sudo apt-get update`
in `Linux`, it works fine. So it can fix the [issue #128](https://github.com/maruos/maruos/issues/128)